### PR TITLE
NeedForHeat API V3 compose files with documentation renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Twomes Backoffice Server Configuration <!-- omit from toc -->
+# NeedForHeat Server Configuration <!-- omit from toc -->
+![GitHub License](https://img.shields.io/github/license/energietransitie/needforheat-server-configuration)
+![Project Status badge](https://img.shields.io/badge/status-in%20progress-brightgreen)
+![Version Status Badge](https://img.shields.io/badge/version-stable-brightgreen)
 
 This repository contains configuration scripts and instructions for configuring a Twomes Backoffice server, comprising of multiple Docker containers hosted on a Linux server, based on the following technologies: [Traefik proxy](https://traefik.io/traefik/), [Portainer](https://www.portainer.io/), [MariaDB](https://mariadb.org/), [CloudBeaver](https://cloudbeaver.io/), [Duplicati](https://www.duplicati.com/), [Twomes Backoffice API](https://github.com/energietransitie/twomes-backoffice-api) and [JupyterLab](https://jupyter.org/).
 
@@ -14,7 +17,6 @@ NB: Where you read `energietransitiewindesheim.nl` below, you should subsitute y
   - [Deploying stacks with Portainer](#deploying-stacks-with-portainer)
 - [Updating](#updating)
 - [Features](#features)
-- [Status](#status)
 - [License](#license)
 - [Credits](#credits)
 
@@ -170,11 +172,6 @@ Optional:
 - [ ] force use of SSH tunnel to `cloudbeaver` container
 - [ ] force use of SSH tunnel to `traefik` container
 
-## Status
-Project is: _in progress_
-
-Current version is stable. Room for improvement.
-
 ## License
 
 This software is available under the [Apache 2.0 license](./LICENSE), 
@@ -187,6 +184,7 @@ This configuration repository was originally created by:
 * Arjan Peddemors · [@arpe](https://github.com/arpe)
 
 It was extended by:
+* Harris Mesic · [@Labhatorian](https://github.com/Labhatorian)
 * Nick van Ravenzwaaij · [@n-vr](https://github.com/n-vr)
 * Erik Krooneman · [@Erikker21](https://github.com/Erikker21)
 * Leon Kampstra · [@LeonKampstra](https://github.com/LeonKampstra)
@@ -202,6 +200,6 @@ We use and gratefully acknowlegde the efforts of the makers of the following tec
 * [MariaDB](https://github.com/MariaDB/server), licensed under [GNU GPL-2.0](https://github.com/MariaDB/server/blob/10.9/COPYING)
 * [CloudBeaver](https://github.com/dbeaver/cloudbeaver), by DBeaver Corp, licensed under [Apache-2.0](https://github.com/dbeaver/cloudbeaver/blob/devel/LICENSE))
 * [Duplicati](https://github.com/duplicati/duplicati), by duplicati.com, licensed under [LGPL-2.1](https://github.com/duplicati/duplicati/blob/master/LICENSE.txt)
-* [Twomes Backoffice API](https://github.com/energietransitie/twomes-backoffice-api), by Research group Energy Transition, Windesheim University of 
-Applied Sciences, licensed under [Apache-2.0](https://github.com/energietransitie/twomes-backoffice-api/blob/main/LICENSE)
+* [NeedForHeat Server API](https://github.com/energietransitie/needforheat-server-api), by Research group Energy Transition, Windesheim University of 
+Applied Sciences, licensed under [Apache-2.0](https://github.com/energietransitie/needforheat-server-api/blob/main/LICENSE)
 * [JupyterLab](https://github.com/jupyterlab/jupyterlab), by Project Jupyter Contributors, licensed under [this license](https://github.com/jupyterlab/jupyterlab/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Project Status badge](https://img.shields.io/badge/status-in%20progress-brightgreen)
 ![Version Status Badge](https://img.shields.io/badge/version-stable-brightgreen)
 
-This repository contains configuration scripts and instructions for configuring a Twomes Backoffice server, comprising of multiple Docker containers hosted on a Linux server, based on the following technologies: [Traefik proxy](https://traefik.io/traefik/), [Portainer](https://www.portainer.io/), [MariaDB](https://mariadb.org/), [CloudBeaver](https://cloudbeaver.io/), [Duplicati](https://www.duplicati.com/), [Twomes Backoffice API](https://github.com/energietransitie/twomes-backoffice-api) and [JupyterLab](https://jupyter.org/).
+This repository contains configuration scripts and instructions for configuring a NeedForHeat Server, comprising of multiple Docker containers hosted on a Linux server, based on the following technologies: [Traefik proxy](https://traefik.io/traefik/), [Portainer](https://www.portainer.io/), [MariaDB](https://mariadb.org/), [CloudBeaver](https://cloudbeaver.io/), [Duplicati](https://www.duplicati.com/), [NeedForHeat Server API](https://github.com/energietransitie/needforheat-server-api) and [JupyterLab](https://jupyter.org/).
 
 NB: Where you read `energietransitiewindesheim.nl` below, you should subsitute your own domain; where you read `etw` below, you should subsitute your own server abbreviation. 
 
@@ -132,7 +132,7 @@ Add a new stack according to the following steps:
 4. Select `git repository` as the build method.
 5. Set the `repository URL` to: 
     ```
-    https://github.com/energietransitie/twomes-backoffice-configuration
+    https://github.com/energietransitie/needforheat-server-configuration
     ```
 6. Set the `repository reference` to:
     ```
@@ -165,7 +165,7 @@ List of features ready and TODOs for future development. Ready:
 
 To-do:
 - [ ] Create only docker-compose file for Traefik instead of .toml files
-- [ ] Integrated deployment of the entire Twomes Backoffice stack
+- [ ] Integrated deployment of the entire NeedForHeat Server stack
 
 Optional:
 - [ ] force use of SSH tunnel to `portainer` container

--- a/api/README.md
+++ b/api/README.md
@@ -1,13 +1,13 @@
-# API v2
+# API v3
 
-The [Twomes Backoffice API](https://github.com/energietransitie/twomes-backoffice-api) is an open souce solution that serves the Twomes REST API to the Twomes WarmteWachter app and Twomes measurement devices based on Twomes firmware and that used a Twomes database based on MariaDB. 
+The [NeedForHeat Server API](https://github.com/energietransitie/needforheat-server-api) is an open souce solution that serves the NeedForHeat REST API to the [NeedForHeat GearUp App](https://github.com/energietransitie/needforheat-gearup-app) and NeedForHeat measurement devices based on NeedForHeat firmware and that used a NeedForHeat database based on MariaDB. 
 
 Follow the steps in the [deploying section of the main README](../README.md#deploying) to create the stack on Portainer, using the compose path and environment variables below.
 
 > **Info**
-> Click [here](https://github.com/energietransitie/twomes-backoffice-configuration/tree/36ebeff11f1cb7c0d57a48db7ac1254c6b9c2061#api) for environment variables for API v1.
+> Click [here](https://github.com/energietransitie/needforheat-server-configuration/tree/36ebeff11f1cb7c0d57a48db7ac1254c6b9c2061#api) for environment variables for API v3.
 >
-> The compose path there is `api/v1/<env>/docker-compose.yml`.
+> The compose path there is `api/v3/<env>/docker-compose.yml`.
 
 ## Compose path
 
@@ -15,12 +15,12 @@ The compose path for this stack is:
 
 ### Production
 ```
-api/v2/prd/docker-compose.yml
+api/v3/prd/docker-compose.yml
 ```
 
 ### Test
 ```
-api/v2/tst/docker-compose.yml
+api/v3/tst/docker-compose.yml
 ```
 
 ## Environment variables
@@ -29,7 +29,7 @@ api/v2/tst/docker-compose.yml
 
 This environment variable is used to set the DSN (data source name) to connect to.
 
-Example values: `readonly_researcher:correcthorsebatterystaple@tcp(mariadb_dev:3306)/twomes`
+Example values: `readonly_researcher:correcthorsebatterystaple@tcp(mariadb_dev:3306)/needforheat`
 
 > The composition of the connection string is as follows: `<db_user>:<db_password>@<protocol>(<db_host>:<db_port>)/<db_name>`.
 >

--- a/api/v3/prd/docker-compose.yml
+++ b/api/v3/prd/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.8"
+services:
+  needforheat-api-v2-prd:
+    image: ghcr.io/energietransitie/needforheat-server-api:latest # Latest is always the latest stable version.
+    container_name: needforheat-api-v3-prd
+    labels:
+      - traefik.http.routers.needforheat-api-v3-prd.rule=Host(`api.energietransitiewindesheim.nl`) && PathPrefix(`/v3`)
+      - traefik.http.routers.needforheat-api-v3-prd.priority=20
+      - traefik.http.middlewares.prod-stripprefix-v3.stripprefix.prefixes=/v3
+      - traefik.http.routers.needforheat-api-v3-prd.tls=true
+      - traefik.http.routers.needforheat-api-v3-prd.tls.certresolver=lets-encrypt
+      - traefik.http.services.needforheat-api-v3-prd.loadbalancer.server.port=8080
+      - traefik.http.routers.needforheat-api-v3-prd.middlewares=prod-ratelimit,prod-stripprefix-v3
+      - traefik.http.middlewares.prod-ratelimit.ratelimit.average=100
+      - traefik.http.middlewares.prod-ratelimit.ratelimit.burst=50
+    networks:
+      - web
+    environment:
+      - NFH_DSN=${NFH_DSN}
+      - NFH_BASE_URL=${NFH_BASE_URL}
+      - NFH_DOWNLOAD_TIME=${NFH_DOWNLOAD_TIME}
+    restart: unless-stopped
+    volumes:
+      - data:/data
+
+networks:
+  web:
+    external: true
+
+volumes:
+  data: {}

--- a/api/v3/tst/docker-compose.yml
+++ b/api/v3/tst/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.8"
+services:
+  needforheat-api-v3-tst:
+    image: ghcr.io/energietransitie/needforheat-server-api:main
+    container_name: needforheat-api-v3-tst
+    labels:
+      - traefik.http.routers.needforheat-api-v3-tst.rule=Host(`api.tst.energietransitiewindesheim.nl`) && PathPrefix(`/v3`)
+      - traefik.http.routers.needforheat-api-v3-tst.priority=20
+      - traefik.http.middlewares.test-stripprefix-v3.stripprefix.prefixes=/v3
+      - traefik.http.routers.needforheat-api-v3-tst.tls=true
+      - traefik.http.routers.needforheat-api-v3-tst.tls.certresolver=lets-encrypt
+      - traefik.http.services.needforheat-api-v3-tst.loadbalancer.server.port=8080
+      - traefik.http.routers.needforheat-api-v3-tst.middlewares=test-ratelimit,test-stripprefix-v3
+      - traefik.http.middlewares.test-ratelimit.ratelimit.average=100
+      - traefik.http.middlewares.test-ratelimit.ratelimit.burst=50
+    networks:
+      - web
+    environment:
+      - NFH_DSN=${NFH_DSN}
+      - NFH_BASE_URL=${NFH_BASE_URL}
+      - NFH_DOWNLOAD_TIME=${NFH_DOWNLOAD_TIME}
+    restart: unless-stopped
+    volumes:
+      - data:/data
+
+networks:
+  web:
+    external: true
+
+volumes:
+  data: {}

--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -18,7 +18,7 @@ jupyter/docker-compose.yml
 
 ### `TWOMES_DB_URL`
 
-This environment variable is used to set the connection string which is used to connect to the Twomes database.
+This environment variable is used to set the connection string which is used to connect to the NeedForHeat database.
 
 Example values: `readonly_researcher:correcthorsebatterystaple@mariadb_dev:3306/twomes_v2`
 

--- a/manuals/README.md
+++ b/manuals/README.md
@@ -1,6 +1,6 @@
 # Manuals
 
-The [Twomes Manual Server](https://github.com/energietransitie/twomes-manual-server) is an open souce solution that serves the twomes manuals.
+The [NeedForHeat Manual Server](https://github.com/energietransitie/needforheat-manual-server) is an open souce solution that serves the NeedForHeat manuals.
 
 Follow the steps in the [deploying section of the main README](../README.md#deploying) to create the stack on Portainer, using the compose path and environment variables below.
 
@@ -22,12 +22,12 @@ manuals/tst/docker-compose.yml
 
 ### `NFH_MANUAL_SOURCE`
 
-This environment variable is used to set the source of the twomes manuals.
+This environment variable is used to set the source of the NeedForHeat manuals.
 
 Example values: `/source` or `https://github.com/<org>/<repo>`
 
 ### `NFH_FALLBACK_LANG`
 
-This environment variable is used to set the fallback language for serving the twomes manuals.
+This environment variable is used to set the fallback language for serving the NeedForHeat manuals.
 
 Example values: `en-GB` or `nl-NL`

--- a/portainer/README.md
+++ b/portainer/README.md
@@ -2,10 +2,10 @@
 
 [Portainer](https://www.portainer.io/) is a web-based continer management solution. 
 
-To deploy the `portainer` container, clone this repository on the server in the home directory of the root user, such that the repository's contents are available at `/root/twomes-backoffice-configuration`. Use the following command in the home directory of the root user (`/root`):
+To deploy the `portainer` container, clone this repository on the server in the home directory of the root user, such that the repository's contents are available at `/root/needforheat-server-configuration`. Use the following command in the home directory of the root user (`/root`):
 ```shell
 cd
-git clone https://github.com/energietransitie/twomes-backoffice-configuration.git
+git clone https://github.com/energietransitie/needforheat-server-configuration.git
 ```
 
 > In the command below, you should substitute `<env>` with your chosen environment (`prd` or `tst`).

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -3,27 +3,27 @@
 [Traefik proxy](https://traefik.io/traefik/) is a reverse proxy and load balancer. All http(s) access to the server goes through the Traefik proxy. This
 proxy takes care of virtual host for multiple subdomains of energietransitiewindesheim.nl, and takes care of Let's Encrypt certificate (re-)generation.
 
-To deploy the `traefik` container, clone this repository on the server in the home directory of the root user, such that the repository's contents are available at `/root/twomes-backoffice-configuration`. Use the following command in the home directory of the root user (`/root`):
+To deploy the `traefik` container, clone this repository on the server in the home directory of the root user, such that the repository's contents are available at `/root/needforheat-server-configuration`. Use the following command in the home directory of the root user (`/root`):
 ```shell
 cd
-git clone https://github.com/energietransitie/twomes-backoffice-configuration.git
+git clone https://github.com/energietransitie/needforheat-server-configuration.git
 ```
 
 > In the rest of the commands concerning traefik, you should substitute `<env>` with your chosen environment (`prd` or `tst`).
 
-On the server, set the proper credentials and IPv4 address(es) in `/root/twomes-backoffice-configuration/traefik/<env>/traefik_dynamic.toml` to access the traefik dashboard. 
-On the server, set the proper credentials for your email in `/root/twomes-backoffice-configuration/traefik/<env>/traefik.toml`. 
+On the server, set the proper credentials and IPv4 address(es) in `/root/needforheat-server-configuration/traefik/<env>/traefik_dynamic.toml` to access the traefik dashboard. 
+On the server, set the proper credentials for your email in `/root/needforheat-server-configuration/traefik/<env>/traefik.toml`. 
 
 On the server, do the following.
 ```shell
 docker network create web
-cd /root/twomes-backoffice-configuration/traefik/<env>
+cd /root/needforheat-server-configuration/traefik/<env>
 touch acme.json
 chmod 600 acme.json
 ```
 
 Start the Traefik proxy
 ```shell
-cd /root/twomes-backoffice-configuration/traefik/<env>
+cd /root/needforheat-server-configuration/traefik/<env>
 docker-compose -p traefik-<env> up -d
 ```


### PR DESCRIPTION
Prepare the files for when we will try to deploy the V3 API with the DataSourceList: https://github.com/energietransitie/needforheat-server-api/pull/160

This will rename pretty much everything from Twomes to NeedForHeat as well, including documentation.